### PR TITLE
GitHub Actions でイメージをビルドする

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,23 @@
+name: Build and Push to GitHub Container Registry
+
+on:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          push: true
+          tags:
+            - ghcr.io/${{ github.actor }}/creusot-devcontainer:git-${{ github.sha }}
+            - ghcr.io/${{ github.actor }}/creusot-devcontainer:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -18,6 +18,6 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           push: true
-          tags:
-            - ghcr.io/${{ github.actor }}/creusot-devcontainer:git-${{ github.sha }}
-            - ghcr.io/${{ github.actor }}/creusot-devcontainer:latest
+          tags: |
+            ghcr.io/${{ github.actor }}/creusot-devcontainer:git-${{ github.sha }}
+            ghcr.io/${{ github.actor }}/creusot-devcontainer:latest

--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -5,8 +5,8 @@ on:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-22.04
-
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v3
@@ -18,6 +18,7 @@ jobs:
       - uses: docker/build-push-action@v5
         with:
           push: true
+          context: ./.devcontainer
           tags: |
             ghcr.io/${{ github.actor }}/creusot-devcontainer:git-${{ github.sha }}
             ghcr.io/${{ github.actor }}/creusot-devcontainer:latest


### PR DESCRIPTION
# What

GitHub Actions でイメージをビルドして、GitHub Container Registry に push する
Closes #1.

# Why

ローカルで毎回ビルドすると重いので。